### PR TITLE
Add flake8 CI, and drop exceptions

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -1,0 +1,36 @@
+---
+
+name: Linting
+on: [pull_request]
+
+jobs:
+  flake8:
+    name: flake8
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+
+      - name: Set up Python 3
+        uses: actions/setup-python@v1
+        with:
+          python-version: 3.8
+
+      - name: Install flake8
+        run: pip3 install 'flake8>=3.8'
+
+      - name: Set up reviewdog
+        run: |
+          mkdir -p "$HOME/bin"
+          curl -sfL \
+            https://github.com/reviewdog/reviewdog/raw/master/install.sh | \
+              sh -s -- -b "$HOME/bin"
+          echo "$HOME/bin" >> $GITHUB_PATH
+
+      - name: Run flake8
+        env:
+          REVIEWDOG_GITHUB_API_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          set -o pipefail
+          flake8 | \
+            reviewdog -f=pep8 -name=flake8 \
+              -tee -reporter=github-check -filter-mode nofilter

--- a/mpl_sphinx_theme/__init__.py
+++ b/mpl_sphinx_theme/__init__.py
@@ -1,4 +1,4 @@
-from ._version import version_info, __version__
+from ._version import version_info, __version__  # noqa: F401
 
 from pathlib import Path
 
@@ -8,7 +8,8 @@ def get_html_theme_path():
     return [str(Path(__file__).parent.parent.resolve())]
 
 
-# See https://www.sphinx-doc.org/en/master/development/theming.html#distribute-your-theme-as-a-python-package
+# For more details, see:
+# https://www.sphinx-doc.org/en/master/development/theming.html#distribute-your-theme-as-a-python-package
 def setup(app):
     app.add_html_theme("mpl_sphinx_theme",
                        str(Path(__file__).parent.resolve()))

--- a/setup.cfg
+++ b/setup.cfg
@@ -3,20 +3,9 @@
 # https://flake8.readthedocs.io/en/latest/user/configuration.html
 # https://flake8.readthedocs.io/en/latest/user/error-codes.html
 
-# Aligned with black https://github.com/psf/black/blob/main/.flake8
-extend-ignore = E203, E266, E501
-# Note: there cannot be spaces after commas here
-exclude = __init__.py,versioneer.py
-ignore =
-    E4,         # Import formatting
-    E731,       # Assigning lambda expression
-    W503,       # line break before binary operator
-
-per-file-ignores =
-    **/tests/*:
-        # local variable is assigned to but never used
-        F841,
-        # Ambiguous variable name
-        E741,
-
-max-line-length = 88
+exclude =
+    .git
+    build
+    # External files.
+    .tox
+    .eggs


### PR DESCRIPTION
We should try to match Matplotlib in flake8 config. The exceptions in Matplotlib are only for backwards-compatibility with existing code and to avoid mass changes, and this code doesn't require any of them, so all exceptions can be dropped.

~~This depends on #16 and #17, and should not be merged before rebasing.~~