### PR TITLE
Ignore editable build files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+/mpl_sphinx_theme.egg-info/
+/mpl_sphinx_theme/__pycache__/


### PR DESCRIPTION
That is, files that come about due to `pip install -e .`.