### PR TITLE
MNT: change usage->user in the menu bar

### DIFF
--- a/mpl_sphinx_theme/mpl_nav_bar.html
+++ b/mpl_sphinx_theme/mpl_nav_bar.html
@@ -13,7 +13,7 @@
     <a class="reference internal nav-link" href="{{ pathto('api/index') }}">Reference</a>
   </li>
   <li class="nav-item">
-    <a class="reference internal nav-link" href="{{ pathto('users/index') }}">Usage guide</a>
+    <a class="reference internal nav-link" href="{{ pathto('users/index') }}">User guide</a>
   </li>
   <li class="nav-item">
     <a class="reference internal nav-link" href="{{ pathto('devel/index') }}">Develop</a>


### PR DESCRIPTION
The Menu bar currently says "Usage Guide", but there is already a "Usage Guide" so I think this should be "User Guide"