### PR TITLE
Make the documentation build reproducibly

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -1,3 +1,5 @@
+import os
+import time
 import datetime
 
 # Configuration file for the Sphinx documentation builder for
@@ -6,11 +8,17 @@ import datetime
 # Release mode enables optimizations and other related options.
 is_release_build = tags.has('release')  # noqa
 
+# Parse year using SOURCE_DATE_EPOCH, falling back to current time.
+# https://reproducible-builds.org/specs/source-date-epoch/
+build_date = datetime.datetime.utcfromtimestamp(
+    int(os.environ.get('SOURCE_DATE_EPOCH', time.time()))
+)
+
 # -- Project information -----------------------------------------------------
 
 project = "Matplotlib Sphinx Theme"
 copyright = (
-    f"2012 - {datetime.datetime.now().year} The Matplotlib development team"
+    f"2012 - {build_date.year} The Matplotlib development team"
 )
 author = "Matplotlib Developers"
 


### PR DESCRIPTION
```
Whilst working on the Reproducible Builds effort [0], I noticed that
mpl-sphinx-theme could not be built reproducibly.

This is because the documentation embedded the current build year. This PR
changes the behaviour of the Sphinx documentation so that it can that
optionally use SOURCE_DATE_EPOCH [1] as the source of this value instead.

I originally filed this in Debian as bug #1005826 [2].

 [0] https://reproducible-builds.org/
 [1] https://reproducible-builds.org/specs/source-date-epoch/
 [2] https://bugs.debian.org/1005826
```