### PR TITLE
Add gh-pages deployment

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,26 +1,25 @@
+---
 version: 2.1
 
 orbs:
-  python: circleci/python@0.2.1
+  python: circleci/python@1.2.1
 
 jobs:
   build_docs:
     executor: python/default
     steps:
       - checkout
-      - python/install-deps
-      - run:
-          name: install theme
-          command: python -m pip install --user -ve .      
+      - python/install-packages:
+          pkg-manager: pip-dist
+          pip-dependency-file: docs/requirements.txt
       - run:
           name: Build docs
-          command: cd docs/ && make html
+          command: make -C docs html
       - persist_to_workspace:
           root: docs/_build/html
           paths: .
       - store_artifacts:
           path: docs/_build/html/
-
 
 workflows:
   main:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -21,7 +21,37 @@ jobs:
       - store_artifacts:
           path: docs/_build/html/
 
+  deploy:
+    docker:
+      - image: "node:8.10.0"
+    steps:
+      - attach_workspace:
+          at: html
+      - run:
+          name: Install and configure dependencies
+          command: |
+            npm install -g --silent gh-pages@2.0.1
+            git config user.email "MatplotlibCircleBot@nomail"
+            git config user.name "MatplotlibCircleBot"
+      - add_ssh_keys:
+          fingerprints:
+            - "25:2e:77:93:7e:0e:af:77:b0:be:e7:fe:86:2c:5b:96"
+      - run:
+          name: "Deploy new docs"
+          command: |
+            touch html/.nojekyll  # Disable jekyll builds on GitHub.
+            gh-pages \
+              --dotfiles \
+              --message "[skip ci] Doc build of $CIRCLE_SHA1" \
+              --dist html
+
 workflows:
   main:
     jobs:
       - build_docs
+      - deploy:
+          requires:
+            - build_docs
+          filters:
+            branches:
+              only: main


### PR DESCRIPTION
Currently, doc builds are part of the PR, but then once done, they disappear at whatever rate CircleCI wishes.

This will post the current theme docs on https://matplotlib.org/mpl-sphinx-theme once merged to `main`, following instructions on [the CircleCI blog post](https://circleci.com/blog/deploying-documentation-to-github-pages-with-continuous-integration/).

