### PR TITLE
Move external links to the very right of the nav bar

### DIFF
--- a/mpl_sphinx_theme/static/css/style.css
+++ b/mpl_sphinx_theme/static/css/style.css
@@ -20,3 +20,7 @@ html[data-theme="dark"] {
 .sidebar-cheatsheets, .sidebar-donate {
   margin: 2.75rem 0;
 }
+
+#navbar-icon-links .nav-link {
+  color: #989898;
+}

--- a/mpl_sphinx_theme/theme.conf
+++ b/mpl_sphinx_theme/theme.conf
@@ -6,5 +6,5 @@ stylesheet = css/style.css
 navbar_links = absolute
 # navbar_start = mpl_navbar_logo.html
 navbar_center = mpl_nav_bar.html
-navbar_end = mpl_icon_links.html, theme-switcher.html
+navbar_end = theme-switcher.html, mpl_icon_links.html
 logo = images/logo2.svg


### PR DESCRIPTION
and color them a bit more light so that they offset from the page-related buttons theme-switch and search-button.

before:
![image](https://user-images.githubusercontent.com/2836374/189473341-25869180-41f6-4b8f-889d-102b99c2a0ba.png)

after:
![image](https://user-images.githubusercontent.com/2836374/189473308-6b16cb02-83fb-447e-81d4-d009b550b792.png)
