### PR TITLE
MNT: update version and pydata-sphinx-theme req

### DIFF
--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,2 +1,2 @@
-pydata-sphinx-theme>=0.9.0
+pydata-sphinx-theme>=0.10.0
 matplotlib

--- a/mpl_sphinx_theme/_version.py
+++ b/mpl_sphinx_theme/_version.py
@@ -4,5 +4,5 @@
 # Copyright (c) Matplotlib developers.
 # Distributed under the terms of the Modified BSD License.
 
-version_info = (3, 5, 0)
+version_info = (3, 6, 0)
 __version__ = ".".join(map(str, version_info))

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,2 @@
-pydata-sphinx-theme>=0.9.0
+pydata-sphinx-theme>=0.10.0
 matplotlib


### PR DESCRIPTION
The changes in #43 require pydata-sphinx-theme >= 0.10.0.  We also did not update the version number here...