### PR TITLE
Color and margin of nav-bar links

### DIFF
--- a/mpl_sphinx_theme/static/css/style.css
+++ b/mpl_sphinx_theme/static/css/style.css
@@ -26,9 +26,10 @@ html[data-theme="dark"] {
 }
 
 #navbar-icon-links .nav-link {
-  color: var(--pst-color-link);
+  color: #989898;
 }
 
 #navbar-icon-links .nav-link:hover {
-  color: var(--pst-color-link-hover);
+  color: var(--pst-color-primary);
 }
+

--- a/mpl_sphinx_theme/static/css/style.css
+++ b/mpl_sphinx_theme/static/css/style.css
@@ -21,6 +21,14 @@ html[data-theme="dark"] {
   margin: 2.75rem 0;
 }
 
+#navbar-icon-links {
+    margin-left: 1.5em;
+}
+
 #navbar-icon-links .nav-link {
-  color: #989898;
+  color: var(--pst-color-link);
+}
+
+#navbar-icon-links .nav-link:hover {
+  color: var(--pst-color-link-hover);
 }


### PR DESCRIPTION
Follow up to #43. (attn. @jklymak)

- Coloring follows regular links
- Add margin to the left so that page control buttons are visually separated.

![image](https://user-images.githubusercontent.com/2836374/189999131-05766862-124d-4d60-b83d-59b2806e85db.png)
