### PR TITLE
change release notes to releases

### DIFF
--- a/mpl_sphinx_theme/mpl_nav_bar.html
+++ b/mpl_sphinx_theme/mpl_nav_bar.html
@@ -18,6 +18,6 @@
     <a class="reference internal nav-link" href="{{ mpl_path('devel/index') }}">Develop</a>
   </li>
   <li class="nav-item">
-    <a class="reference internal nav-link" href="{{ mpl_path('users/release_notes') }}">Release notes</a>
+    <a class="reference internal nav-link" href="{{ mpl_path('users/release_notes') }}">Releases</a>
   </li>
 </ul>


### PR DESCRIPTION
quick fix for #50 by shortening Release Notes to Releases. 

could also maybe make following changes but out of scope 'cause a whole discussion:
Reference -> API 
Plot types -> Plots
and not a shorten but Develop -> Contribute

ETA: This built doc doesn't show the dev dropdown so I can't tell if it fixes the problem. ☹️ 