### PR TITLE
Fix link icon sizes

### DIFF
--- a/mpl_sphinx_theme/mpl_icon_links.html
+++ b/mpl_sphinx_theme/mpl_icon_links.html
@@ -1,9 +1,9 @@
 {%- if not theme_icon_links -%}
   {%- set theme_icon_links = [
-    { "url": "https://gitter.im/matplotlib", "icon": "fab fa-gitter", "name": "Gitter" },
-    { "url": "https://discourse.matplotlib.org", "icon": "fab fa-discourse", "name": "Discourse" },
-    { "url": "https://github.com/matplotlib/matplotlib", "icon": "fab fa-github", "name": "GitHub" },
-    { "url": "https://twitter.com/matplotlib/", "icon": "fab fa-twitter", "name": "Twitter" },
+    { "url": "https://gitter.im/matplotlib", "icon": "fa-brands fa-gitter", "name": "Gitter" },
+    { "url": "https://discourse.matplotlib.org", "icon": "fa-brands fa-discourse", "name": "Discourse" },
+    { "url": "https://github.com/matplotlib/matplotlib", "icon": "fa-brands fa-github", "name": "GitHub" },
+    { "url": "https://twitter.com/matplotlib/", "icon": "fa-brands fa-twitter", "name": "Twitter" },
   ] -%}
 {%- endif -%}
 {% extends "navbar-icon-links.html" %}

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,2 @@
-pydata-sphinx-theme>=0.10.0
+pydata-sphinx-theme>=0.11.0
 matplotlib


### PR DESCRIPTION
They are controlled by pydata-sphinx-theme.css. However, pydata-sphinx-theme changed the classes in v0.11.0 https://github.com/pydata/pydata-sphinx-theme/pull/963. We need to update this as well.