### PR TITLE
Mnt/restore doc sha

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 /mpl_sphinx_theme.egg-info/
 /mpl_sphinx_theme/__pycache__/
+build

--- a/mpl_sphinx_theme/__init__.py
+++ b/mpl_sphinx_theme/__init__.py
@@ -31,7 +31,10 @@ def setup_html_page_context(app, pagename, templatename, context, doctree):
 # For more details, see:
 # https://www.sphinx-doc.org/en/master/development/theming.html#distribute-your-theme-as-a-python-package
 def setup(app):
-    app.add_html_theme("mpl_sphinx_theme",
-                       str(Path(__file__).parent.resolve()))
+    here = Path(__file__).parent.resolve()
+    # Include component templates
+    app.config.templates_path.append(str(here / "components"))
+
+    app.add_html_theme("mpl_sphinx_theme", str(here))
     app.connect("html-page-context", setup_html_page_context)
     return {'version': __version__, 'parallel_read_safe': True}

--- a/mpl_sphinx_theme/components/doc_version.html
+++ b/mpl_sphinx_theme/components/doc_version.html
@@ -1,6 +1,6 @@
-{% if lib_version %}
+{% if doc_version %}
   <p class="sphinx-version">
-    Built from {{ lib_version }}.
+    Built from {{ doc_version }}.
     <br/>
   </p>
 {% endif %}

--- a/mpl_sphinx_theme/components/lib_version.html
+++ b/mpl_sphinx_theme/components/lib_version.html
@@ -1,0 +1,6 @@
+{% if lib_version %}
+  <p class="sphinx-version">
+    Built from {{ lib_version }}.
+    <br/>
+  </p>
+{% endif %}

--- a/setup.py
+++ b/setup.py
@@ -22,6 +22,7 @@ setup(
             "static/images/*.ico",
             "static/js/*.js",
             "static/font/*.*",
+            "components/*.html",
         ]
     },
     include_package_data=True,


### PR DESCRIPTION
We used to include the exact commit used to build the docs in the footer (see https://matplotlib.org/3.4.3/index.html) however that got lost as part of the move to mpl-sphinx-theme.  This adds the option to put this in the footer again.