### PR TITLE
Fix gitter link in top navbar

### DIFF
--- a/mpl_sphinx_theme/mpl_icon_links.html
+++ b/mpl_sphinx_theme/mpl_icon_links.html
@@ -1,6 +1,6 @@
 {%- if not theme_icon_links -%}
   {%- set theme_icon_links = [
-    { "url": "https://gitter.im/matplotlib", "icon": "fa-brands fa-gitter", "name": "Gitter" },
+    { "url": "https://gitter.im/matplotlib/matplotlib", "icon": "fa-brands fa-gitter", "name": "Gitter" },
     { "url": "https://discourse.matplotlib.org", "icon": "fa-brands fa-discourse", "name": "Discourse" },
     { "url": "https://github.com/matplotlib/matplotlib", "icon": "fa-brands fa-github", "name": "GitHub" },
     { "url": "https://twitter.com/matplotlib/", "icon": "fa-brands fa-twitter", "name": "Twitter" },


### PR DESCRIPTION
This was [reported on twitter](https://twitter.com/OpenTechPark/status/1633536096003842061?t=adEdQHOLzf_-U1UxDpPklQ&s=19): the gitter link in the top navbar returns a 404 - perhaps this is a result of the recent changes at gitter.