### PR TITLE
Merge tag 3.7.1 into main

### DIFF
--- a/mpl_sphinx_theme/_version.py
+++ b/mpl_sphinx_theme/_version.py
@@ -4,5 +4,5 @@
 # Copyright (c) Matplotlib developers.
 # Distributed under the terms of the Modified BSD License.
 
-version_info = (3, 7, 0)
+version_info = (3, 7, 1)
 __version__ = ".".join(map(str, version_info))


### PR DESCRIPTION
- Add compatibility with pydata-sphinx-theme 0.13.0
- Fix broken gitter link in navbar
- Allow setting release-specific navbar link modes