### PR TITLE
Change develop in nav bar to contribute

### DIFF
--- a/mpl_sphinx_theme/mpl_nav_bar.html
+++ b/mpl_sphinx_theme/mpl_nav_bar.html
@@ -15,7 +15,7 @@
     <a class="reference internal nav-link" href="{{ mpl_path('users/index') }}">User guide</a>
   </li>
   <li class="nav-item">
-    <a class="reference internal nav-link" href="{{ mpl_path('devel/index') }}">Develop</a>
+    <a class="reference internal nav-link" href="{{ mpl_path('devel/index') }}">Contribute</a>
   </li>
   <li class="nav-item">
     <a class="reference internal nav-link" href="{{ mpl_path('users/release_notes') }}">Releases</a>


### PR DESCRIPTION
Way back when, this section of the docs was named contribute. We changed it to develop at some point but that feels too narrow so this restores the name of that section to contribute 