### PR TITLE
organize navbar in overview->details order

### DIFF
--- a/mpl_sphinx_theme/mpl_nav_bar.html
+++ b/mpl_sphinx_theme/mpl_nav_bar.html
@@ -3,16 +3,16 @@
     <a class="reference internal nav-link" href="{{ mpl_path('plot_types/index') }}">Plot types</a>
   </li>
   <li class="nav-item">
-    <a class="reference internal nav-link" href="{{ mpl_path('gallery/index') }}">Examples</a>
+    <a class="reference internal nav-link" href="{{ mpl_path('users/index') }}">User guide</a>
   </li>
   <li class="nav-item">
     <a class="reference internal nav-link" href="{{ mpl_path('tutorials/index') }}">Tutorials</a>
   </li>
   <li class="nav-item">
-    <a class="reference internal nav-link" href="{{ mpl_path('api/index') }}">Reference</a>
+    <a class="reference internal nav-link" href="{{ mpl_path('gallery/index') }}">Examples</a>
   </li>
-  <li class="nav-item">
-    <a class="reference internal nav-link" href="{{ mpl_path('users/index') }}">User guide</a>
+   <li class="nav-item">
+    <a class="reference internal nav-link" href="{{ mpl_path('api/index') }}">Reference</a>
   </li>
   <li class="nav-item">
     <a class="reference internal nav-link" href="{{ mpl_path('devel/index') }}">Develop</a>

--- a/mpl_sphinx_theme/mpl_nav_bar.html
+++ b/mpl_sphinx_theme/mpl_nav_bar.html
@@ -11,7 +11,7 @@
   <li class="nav-item">
     <a class="reference internal nav-link" href="{{ mpl_path('gallery/index') }}">Examples</a>
   </li>
-   <li class="nav-item">
+  <li class="nav-item">
     <a class="reference internal nav-link" href="{{ mpl_path('api/index') }}">Reference</a>
   </li>
   <li class="nav-item">


### PR DESCRIPTION
Um this is a first pass rather than something I'm strongly attached to, but I'm proposing the following story right to left because it goes from overview of the library to details on demand. I continue to not really know where to place tutorials but the middle kinda makes sense

- plot types -> user guide -> tutorials -> examples -> reference