### PR TITLE
CI: Drop fetch-tags setting from checkout step

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -14,7 +14,6 @@ jobs:
       - uses: actions/checkout@v4
         with:
           fetch-depth: 10
-          fetch-tags: true
 
       - name: Set up Python
         id: setup


### PR DESCRIPTION
This seems to cause a conflict when the workflow is triggered by a tag itself: https://github.com/actions/checkout/issues/1467