### PR TITLE
SVGs are not in a subfolder

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -43,7 +43,7 @@ mpl_sphinx_theme = [
     "theme.conf",
     "*.html",
     "static/css/*.css",
-    "static/images/*.svg",
+    "static/*.svg",
     "static/images/*.ico",
     "static/js/*.js",
     "static/font/*.*",


### PR DESCRIPTION
This lead to the logos being missing from the wheels/install