### PR TITLE
Merge v3.8.x branch up to main

### DIFF
--- a/mpl_sphinx_theme/_version.py
+++ b/mpl_sphinx_theme/_version.py
@@ -4,5 +4,5 @@
 # Copyright (c) Matplotlib developers.
 # Distributed under the terms of the Modified BSD License.
 
-version_info = (3, 8, 0)
-__version__ = ".".join(map(str, version_info))
+version_info = (3, 8, 1)
+__version__ = ".".join(map(str, version_info)) + "dev0"

--- a/mpl_sphinx_theme/_version.py
+++ b/mpl_sphinx_theme/_version.py
@@ -4,5 +4,5 @@
 # Copyright (c) Matplotlib developers.
 # Distributed under the terms of the Modified BSD License.
 
-version_info = (3, 8, 1)
+version_info = (3, 9, 0)
 __version__ = ".".join(map(str, version_info)) + "dev0"

--- a/mpl_sphinx_theme/_version.py
+++ b/mpl_sphinx_theme/_version.py
@@ -4,5 +4,5 @@
 # Copyright (c) Matplotlib developers.
 # Distributed under the terms of the Modified BSD License.
 
-version_info = (3, 8, 1)
-__version__ = ".".join(map(str, version_info)) + "dev0"
+version_info = (3, 8, 0)
+__version__ = ".".join(map(str, version_info)) + "rc2"

--- a/mpl_sphinx_theme/_version.py
+++ b/mpl_sphinx_theme/_version.py
@@ -5,4 +5,4 @@
 # Distributed under the terms of the Modified BSD License.
 
 version_info = (3, 8, 0)
-__version__ = ".".join(map(str, version_info)) + "rc2"
+__version__ = ".".join(map(str, version_info))


### PR DESCRIPTION
Also, bump version to 3.9.0dev0 so that it will continue to be installed correctly on `devdocs` builds, but not in the `v3.8.x` branch.