### PR TITLE
Always use search icon instead of search box

### DIFF
--- a/mpl_sphinx_theme/theme.conf
+++ b/mpl_sphinx_theme/theme.conf
@@ -6,4 +6,5 @@ stylesheet = css/style.css
 navbar_links = absolute
 navbar_center = mpl_nav_bar.html
 navbar_end = theme-switcher.html, mpl_icon_links.html
+navbar_persistent = search-button.html
 logo = logo_light.svg


### PR DESCRIPTION
With `pydata-sphinx-theme` 0.14, the default search UI changed to a search box. As noted in https://github.com/matplotlib/mpl-sphinx-theme/issues/80 this breaks the theme look, squashing the top navbar too much.

This PR configures search to be a button again.
