### PR TITLE
Pin exact version of pydata-sphinx-theme

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -19,7 +19,7 @@ classifiers = [
     "Topic :: Documentation :: Sphinx",
 ]
 dependencies = [
-    "pydata-sphinx-theme>=0.13.1",
+    "pydata-sphinx-theme==0.13.3",
     "matplotlib",
 ]
 


### PR DESCRIPTION
Since the goal of this sphinx theme is to maintain a consistent look across multiple documentation builds, it makes sense to pin the exact version of `pydata-sphinx-theme` to prevent different doc bulids being done with different versions and looking different.

This also allows us to bump this pin only when we've checked there aren't any issues with the next `pydata-sphinx-theme` version (e.g. see https://github.com/matplotlib/mpl-sphinx-theme/issues/80 for recent issues).