### PR TITLE
Prepare 3.9.0 release

### DIFF
--- a/mpl_sphinx_theme/_version.py
+++ b/mpl_sphinx_theme/_version.py
@@ -5,4 +5,4 @@
 # Distributed under the terms of the Modified BSD License.
 
 version_info = (3, 9, 0)
-__version__ = ".".join(map(str, version_info)) + "rc1"
+__version__ = ".".join(map(str, version_info))

--- a/mpl_sphinx_theme/_version.py
+++ b/mpl_sphinx_theme/_version.py
@@ -4,5 +4,5 @@
 # Copyright (c) Matplotlib developers.
 # Distributed under the terms of the Modified BSD License.
 
-version_info = (3, 9, 0)
-__version__ = ".".join(map(str, version_info))
+version_info = (3, 9, 1)
+__version__ = ".".join(map(str, version_info)) + "dev0"


### PR DESCRIPTION
Somewhat like #77, I will tag off of the `REL: 3.9.0` commit once this is okay.
