### PR TITLE
Improvements to LH sidebar layout

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -61,6 +61,12 @@ html_theme_options = {
     "navbar_links": "absolute",
 }
 
+html_sidebars = {
+    "index": [
+        "donate_sidebar.html",
+    ],
+}
+
 # Add any paths that contain custom static files (such as style sheets) here,
 # relative to this directory. They are copied after the builtin static files,
 # so a file named "default.css" will overwrite the builtin "default.css".

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -29,7 +29,8 @@ author = "Matplotlib Developers"
 # extensions coming with Sphinx (named 'sphinx.ext.*') or your custom
 # ones.
 extensions = [
-    'matplotlib.sphinxext.plot_directive',
+    "matplotlib.sphinxext.plot_directive",
+    "sphinx_design"
 ]
 
 # Add any paths that contain templates here, relative to this directory.

--- a/mpl_sphinx_theme/donate_sidebar.html
+++ b/mpl_sphinx_theme/donate_sidebar.html
@@ -1,8 +1,5 @@
-
-
-
 <div class="sidebar-donate">
-  <a href="https://numfocus.org/donate-to-matplotlib" target="_blank">
-    <span class="mpl-button" >Support Matplotlib</span>
-  </a>
-</div>
+    <a class="sd-btn sd-btn-primary sd-fs-5 sd-px-5 sd-py-2" href="https://numfocus.org/donate-to-matplotlib" target="_blank">
+      Support Matplotlib
+    </a>
+  </div>

--- a/mpl_sphinx_theme/static/css/style.css
+++ b/mpl_sphinx_theme/static/css/style.css
@@ -14,15 +14,23 @@ html[data-theme="dark"] {
 }
 
 :root {
---pst-color-link-hover: var(--pst-color-secondary);
+  --pst-color-link-hover: var(--pst-color-secondary);
 }
 
-.sidebar-cheatsheets, .sidebar-donate {
-  margin: 2.75rem 0;
+.sidebar-cheatsheets > h3 {
+  margin-top: 0;
+}
+
+.sidebar-cheatsheets > img {
+  width: 100%;
+}
+
+.sidebar-donate > .sd-btn {
+  width: 100%;
 }
 
 #navbar-icon-links {
-    margin-left: 1.5em;
+  margin-left: 1.5em;
 }
 
 #navbar-icon-links .nav-link {
@@ -32,4 +40,3 @@ html[data-theme="dark"] {
 #navbar-icon-links .nav-link:hover {
   color: var(--pst-color-primary);
 }
-

--- a/mpl_sphinx_theme/static/css/style.css
+++ b/mpl_sphinx_theme/static/css/style.css
@@ -17,14 +17,6 @@ html[data-theme="dark"] {
   --pst-color-link-hover: var(--pst-color-secondary);
 }
 
-.sidebar-cheatsheets > h3 {
-  margin-top: 0;
-}
-
-.sidebar-cheatsheets > img {
-  width: 100%;
-}
-
 .sidebar-donate > .sd-btn {
   width: 100%;
 }

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -21,6 +21,7 @@ classifiers = [
 dependencies = [
     "pydata-sphinx-theme>=0.13.1",
     "matplotlib",
+    "sphinx-design",
 ]
 
 [project.urls]


### PR DESCRIPTION
This improves the layout of the donate button by stretching it to fill the full width of the sidebar. In order to test this I've also added the current donate button sidebar from https://github.com/matplotlib/matplotlib. This adds a dependency of `sphinx-design` here. I've done this in the spirit of keeping all the code for the donate button in `mpl-sphinx-theme`, so it can be used by other projects, not just the main Matplotlib docs.

In conjunction with https://github.com/matplotlib/matplotlib/pull/29789, this improves the layout:

Before:
<img width="1419" alt="Screenshot 2025-03-21 at 11 48 01" src="https://github.com/user-attachments/assets/75176196-44ef-4a84-9b06-1a33f0f190ce" />

After:

<img width="1365" alt="Screenshot 2025-03-21 at 12 50 14" src="https://github.com/user-attachments/assets/6fe939a3-a747-4bf4-9ab3-1f8711ebe828" />
