### PR TITLE
Reduce height of nav bar when items don't fit in one line

### DIFF
--- a/mpl_sphinx_theme/static/css/style.css
+++ b/mpl_sphinx_theme/static/css/style.css
@@ -32,3 +32,11 @@ html[data-theme="dark"] {
 #navbar-icon-links .nav-link:hover {
   color: var(--pst-color-primary);
 }
+
+/* reduce height of nav bar when items don't fit in one line
+   See https://github.com/pydata/pydata-sphinx-theme/pull/2117
+ */
+.navbar-item {
+  height: unset !important;
+  margin: 0.25rem 0;
+}


### PR DESCRIPTION
Since pydata-sphinx-theme is not making progress with reasonably displaying lot of content in the nav bar on medium-width screens, let's put the relatively simple workaround from
https://github.com/pydata/pydata-sphinx-theme/pull/2117 into the mpl-sphinx-theme.

before:
<img width="986" height="134" alt="image" src="https://github.com/user-attachments/assets/f38fdea4-bca3-4c59-b141-dd0532d66234" />

after:
<img width="986" height="84" alt="image" src="https://github.com/user-attachments/assets/fb3268ac-3da1-4c33-a9ad-a9bad96986b4" />
