### PR TITLE
Pin exact version of pydata-sphinx-theme

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -2,11 +2,13 @@
 version: 2.1
 
 orbs:
-  python: circleci/python@1.2.1
+  python: circleci/python@3.2.0
 
 jobs:
   build_docs:
-    executor: python/default
+    executor:
+      name: python/default
+      tag: "3.11"
     steps:
       - checkout
       - python/install-packages:

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -9,3 +9,12 @@ updates:
       actions:
         patterns:
           - "*"
+
+  - package-ecosystem: "pip"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    groups:
+      python:
+        patterns:
+          - "*"

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,3 +1,0 @@
-{
-    "editor.formatOnSave": false
-}

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,3 @@
+{
+    "editor.formatOnSave": false
+}

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -19,7 +19,7 @@ classifiers = [
     "Topic :: Documentation :: Sphinx",
 ]
 dependencies = [
-    "pydata-sphinx-theme>=0.13.1",
+    "pydata-sphinx-theme==0.15.4",
     "matplotlib",
 ]
 


### PR DESCRIPTION
Currently to get a consistent look across all the Matplotlib website repositories requires pinning `pydata-sphinx-theme` in each repository. To prevent having to do that, this PR pins `pydata-sphinx-theme` here, and adds dependabot configuration to automatically update this as new versions come out.

To start with I've pinned at 0.15.4 because this is what version `matplotlib/matplotlib` is on, and it will also test that dependabot is working (it should try to update to 0.16.x).