### PR TITLE
Break circular dependency

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -11,9 +11,9 @@ jobs:
       tag: "3.11"
     steps:
       - checkout
-      - python/install-packages:
-          pkg-manager: pip-dist
-          pip-dependency-file: docs/requirements.txt
+      - run:
+          name: Install dependencies
+          command: pip install --group doc -e .
       - run:
           name: Build docs
           command: make -C docs html

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -6,6 +6,6 @@ Installing the theme itself:
 
 After following the contribution guidelines in the Matplotlib docs, you will still need to install the theme itself to see the changes you made. At the root level of the repository run:
 
-`python -m pip install -e .`
+`python -m pip install --group doc -e .`
 
 After that you will be able to build the docs locally by doing `make html` in the `docs` directory.

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,2 +1,0 @@
-pydata-sphinx-theme>=0.13.1
-matplotlib

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -54,3 +54,20 @@ mpl_sphinx_theme = [
     "static/font/*.*",
     "components/*.html",
 ]
+
+
+[tool.pixi.workspace]
+channels = ["conda-forge"]
+platforms = ["linux-64", "osx-arm64", "osx-64", "win-64"]
+preview = ["pixi-build"]
+
+
+[tool.pixi.package]
+version = "3.11.1dev"
+name = "mpl-sphinx-theme"
+
+[tool.pixi.package.build.backend]
+name = "pixi-build-python"
+
+[tool.pixi.package.build.config]
+ignore-pypi-mapping = false

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -20,8 +20,12 @@ classifiers = [
 ]
 dependencies = [
     "pydata-sphinx-theme==0.20.0",
-    "matplotlib",
     "sphinx-design",
+]
+
+[dependency-groups]
+doc = [
+     "matplotlib"
 ]
 
 [project.urls]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -63,7 +63,7 @@ preview = ["pixi-build"]
 
 
 [tool.pixi.package]
-version = "3.11.1dev"
+version = "3.11.1.dev0"
 name = "mpl-sphinx-theme"
 
 [tool.pixi.package.build.backend]


### PR DESCRIPTION
mpl-sphinx-theme depends on matplotlib which makes setting up the dev environment with pixi annoying.

mpl-sphinx-theme does not actually use Matplotlib, but the docs do.

While I was touching this I moved to PEP 735 dependency groups.  I used the robot to write the pip syntax for me and check that I got all the references doc/requirements (I regret this).

This also add the pixi build meta-data so we can directly install this via pixi on Matplotlib. 